### PR TITLE
fix: podgen-1.0.0 写入文件时使用系统用户默认编码

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-podgen==1.0.0
+podgen==1.0.1
 pytz==2018.7
 requests==2.20.0


### PR DESCRIPTION
环境: Win10, Python 3.6.2
使用命令生成蜻蜓FM专辑的 .rss 文件, 试图导入到 AntennaPod 时发现标题乱码,
发现文件是 GBK 编码.
最后发现是 podgen 1.0.0 的问题,
相关 issue: https://github.com/tobinus/python-podgen/issues/65